### PR TITLE
feat: update to entirely rely on OTEL config

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
-            testbench: 8.*
+            testbench: ^8.21
           - laravel: 11.*
             testbench: 9.*
 
@@ -34,7 +34,6 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
           coverage: none
 
       - name: Setup problem matchers

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ You can publish the config file with:
 ```shell
 php artisan vendor:publish --tag="laravel-telemetry-config"
 ```
+
 ## Usage
 
 This package will work out of the box with a default OTLP exporter configuration.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,17 @@
+# Upgrade Guide
+
+## Upgrading To 0.5 From 0.4.x
+
+### Configuration Changes
+
+The `telemetry.enabled` configuration key has been moved and negated to `sdk.disabled` to match the underlying
+OpenTelemetry SDK.
+
+Please update this value in your configuration if it has been published.
+
+```diff
+-    'enabled' => env('LARAVEL_TELEMETRY_ENABLED', true),
++    'sdk' => [
++        'disabled' => ! env('LARAVEL_TELEMETRY_ENABLED', true)
++    ],
+```

--- a/composer.json
+++ b/composer.json
@@ -17,19 +17,20 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^10.0 || ^11.0",
+        "illuminate/contracts": "^10.48 || ^11.0",
         "open-telemetry/api": "^1.0.3",
         "open-telemetry/sdk": "^1.0.8",
-        "open-telemetry/exporter-otlp": "^1.0.3",
+        "open-telemetry/exporter-otlp": "^1.0.4",
         "php-http/guzzle7-adapter": "^1.0"
     },
     "require-dev": {
+        "google/protobuf": "^3.25",
+        "larastan/larastan": "^2.9",
         "nunomaduro/collision": "^7.10 || ^8.1",
-        "larastan/larastan": "^2.8",
-        "orchestra/testbench": "^8.15 || ^9.0",
-        "pestphp/pest": "^2.33",
-        "pestphp/pest-plugin-laravel": "^2.2",
-        "worksome/coding-style": "^2.8"
+        "orchestra/testbench": "^8.21.1 || ^9.2",
+        "pestphp/pest": "^2.34",
+        "pestphp/pest-plugin-laravel": "^2.4",
+        "worksome/coding-style": "^2.11"
     },
     "autoload": {
         "psr-4": {

--- a/config/telemetry.php
+++ b/config/telemetry.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 // The Configuration is based on OpenTelemetry's naming convention.
 return [
 
-    'enabled' => env('LARAVEL_TELEMETRY_ENABLED', true),
+    'sdk' => [
+        'disabled' => ! env('LARAVEL_TELEMETRY_ENABLED', true)
+    ],
 
     'exporter' => [
         'otlp' => [

--- a/src/ConfigConfigurationResolver.php
+++ b/src/ConfigConfigurationResolver.php
@@ -4,22 +4,28 @@ declare(strict_types=1);
 
 namespace Worksome\LaravelTelemetry;
 
-use Illuminate\Contracts\Config\Repository;
 use OpenTelemetry\SDK\Common\Configuration\Resolver\ResolverInterface;
 
 /**
  * Resolves Open Telemetry configuration via Laravel config.
+ *
+ * The `config()` function is intentionally used to ensure that the latest config is always used.
  */
 class ConfigConfigurationResolver implements ResolverInterface
 {
     private const PREFIX = 'telemetry';
 
-    public function __construct(
-        private readonly Repository $config,
-    ) {
+    public function retrieveValue(string $variableName)
+    {
+        return config()->get($this->variableNameToConfigKey($variableName));
     }
 
-    private function getKey(string $variableName): string
+    public function hasVariable(string $variableName): bool
+    {
+        return config()->has($this->variableNameToConfigKey($variableName));
+    }
+
+    private function variableNameToConfigKey(string $variableName): string
     {
         $names = collect(explode('_', $variableName))
             ->map(fn(string $key) => strtolower($key))
@@ -27,15 +33,5 @@ class ConfigConfigurationResolver implements ResolverInterface
             ->all();
 
         return implode('.', [self::PREFIX, ...$names]);
-    }
-
-    public function retrieveValue(string $variableName)
-    {
-        return $this->config->get($this->getKey($variableName));
-    }
-
-    public function hasVariable(string $variableName): bool
-    {
-        return $this->config->has($this->getKey($variableName));
     }
 }

--- a/src/LaravelTelemetryServiceProvider.php
+++ b/src/LaravelTelemetryServiceProvider.php
@@ -88,10 +88,10 @@ class LaravelTelemetryServiceProvider extends ServiceProvider
     {
         /** @var LoggerInterface $logger */
         $logger = $this->app->get(LoggerInterface::class);
-        /** @var ConfigConfigurationResolver $configResolver */
-        $configResolver = $this->app->get(ConfigConfigurationResolver::class);
 
         LoggerHolder::set($logger);
-        CompositeResolver::instance()->addResolver($configResolver);
+        CompositeResolver::instance()->addResolver(
+            new ConfigConfigurationResolver()
+        );
     }
 }

--- a/src/LaravelTelemetryServiceProvider.php
+++ b/src/LaravelTelemetryServiceProvider.php
@@ -55,9 +55,7 @@ class LaravelTelemetryServiceProvider extends ServiceProvider
             'telemetry',
         );
 
-        $this->app->beforeResolving(LoggerProviderInterface::class, $this->prepareConfigResolver(...));
-        $this->app->beforeResolving(MeterProviderInterface::class, $this->prepareConfigResolver(...));
-        $this->app->beforeResolving(TracerProviderInterface::class, $this->prepareConfigResolver(...));
+        $this->prepareConfigResolver();
 
         $this->callAfterResolving(Dispatcher::class, function (Dispatcher $event) {
             if ($this->app->make(Repository::class)->get('telemetry.sdk.disabled')) {

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -1,5 +1,0 @@
-<?php
-
-it('can test', function () {
-    expect(true)->toBeTrue();
-});

--- a/tests/Feature/LaravelTelemetryServiceProviderTest.php
+++ b/tests/Feature/LaravelTelemetryServiceProviderTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Config\Repository as ConfigRepository;
+use OpenTelemetry\API\Logs\LoggerInterface;
+use OpenTelemetry\API\Logs\LoggerProviderInterface;
+use OpenTelemetry\API\Logs\NoopLogger;
+use OpenTelemetry\API\Metrics\MeterInterface;
+use OpenTelemetry\API\Metrics\MeterProviderInterface;
+use OpenTelemetry\API\Metrics\Noop\NoopMeter;
+use OpenTelemetry\API\Trace\NoopTracer;
+use OpenTelemetry\API\Trace\TracerInterface;
+use OpenTelemetry\API\Trace\TracerProviderInterface;
+use OpenTelemetry\SDK\Logs\LoggerProviderInterface as LoggerProviderSdkInterface;
+use OpenTelemetry\SDK\Metrics\MeterProviderInterface as MeterProviderSdkInterface;
+use OpenTelemetry\SDK\Sdk;
+use OpenTelemetry\SDK\Trace\TracerProviderInterface as TracerProviderSdkInterface;
+
+it('registers the default config', function () {
+    /** @var ConfigRepository $config */
+    $config = $this->app->get(ConfigRepository::class);
+
+    expect($config->get('telemetry'))
+        ->sdk->disabled->toBeFalse()
+        ->exporter->otlp->endpoint->toBe('http://localhost:4318');
+});
+
+it('can update the config at runtime', function () {
+    /** @var ConfigRepository $config */
+    $config = $this->app->get(ConfigRepository::class);
+
+    expect(Sdk::isDisabled())->toBeFalse();
+
+    $config->set('telemetry.sdk.disabled', true);
+
+    expect(Sdk::isDisabled())->toBeTrue();
+});
+
+it('registers the logger provider', function () {
+    expect(
+        $this->app->get(LoggerProviderInterface::class)
+    )
+        ->toBeInstanceOf(LoggerProviderInterface::class)
+        ->toBeInstanceOf(LoggerProviderSdkInterface::class);
+});
+
+it('registers the metric provider', function () {
+    expect(
+        $this->app->get(MeterProviderInterface::class)
+    )
+        ->toBeInstanceOf(MeterProviderInterface::class)
+        ->toBeInstanceOf(MeterProviderSdkInterface::class);
+});
+
+it('registers the tracer provider', function () {
+    expect(
+        $this->app->get(TracerProviderInterface::class)
+    )
+        ->toBeInstanceOf(TracerProviderInterface::class)
+        ->toBeInstanceOf(TracerProviderSdkInterface::class);
+});
+
+it('can get a logger from the logger provider', function () {
+    expect(
+        $this->app->get(LoggerProviderInterface::class)->getLogger('test')
+    )
+        ->toBeInstanceOf(LoggerInterface::class);
+});
+
+it('can get a meter from the meter provider', function () {
+    expect(
+        $this->app->get(MeterProviderInterface::class)->getMeter('test')
+    )
+        ->toBeInstanceOf(MeterInterface::class);
+});
+
+it('can get a tracer from the tracer provider', function () {
+    expect(
+        $this->app->get(TracerProviderInterface::class)->getTracer('test')
+    )
+        ->toBeInstanceOf(TracerInterface::class);
+});
+
+it('returns no-op instances when the SDK is disabled', function () {
+    /** @var ConfigRepository $config */
+    $config = $this->app->get(ConfigRepository::class);
+
+    $config->set('telemetry.sdk.disabled', true);
+
+    expect(
+        $this->app->get(LoggerProviderInterface::class)->getLogger('test')
+    )
+        ->toBeInstanceOf(NoopLogger::class);
+
+    expect(
+        $this->app->get(MeterProviderInterface::class)->getMeter('test')
+    )
+        ->toBeInstanceOf(NoopMeter::class);
+
+    expect(
+        $this->app->get(TracerProviderInterface::class)->getTracer('test')
+    )
+        ->toBeInstanceOf(NoopTracer::class);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Worksome\LaravelTelemetry\Tests\TestCase;
 
-uses(TestCase::class)->in(__DIR__);
+uses(TestCase::class)->in('Feature');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,38 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Worksome\LaravelTelemetry\Tests;
 
-use Illuminate\Database\Eloquent\Factories\Factory;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Worksome\LaravelTelemetry\LaravelTelemetryServiceProvider;
 
-class TestCase extends Orchestra
+abstract class TestCase extends Orchestra
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        Factory::guessFactoryNamesUsing(
-            fn (string $modelName) => 'Worksome\\LaravelTelemetry\\Database\\Factories\\' . class_basename(
-                $modelName
-            ) . 'Factory'
-        );
-    }
-
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return [
             LaravelTelemetryServiceProvider::class,
         ];
-    }
-
-    public function getEnvironmentSetUp($app)
-    {
-        config()->set('database.default', 'testing');
-
-        /*
-        $migration = include __DIR__.'/../database/migrations/create_laravel-telemetry_table.php.stub';
-        $migration->up();
-        */
     }
 }


### PR DESCRIPTION
This updates to remove the `telemetry.enabled` config key, and move to fully match the OTEL SDK configuration. This makes usage easier, and also means that "no-op" instances will be used, rather than returning `null` for the bindings.

It also cleans up nnecessary code complication (e.g. the full initialisation of `MeterProvider`), ensures that changes to the config in runtime apply to the OTEL SDK, and adds some initial tests.